### PR TITLE
Fix Flutter plugin apply method

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -16,5 +16,3 @@ pluginManagement {
 }
 
 include ":app"
-
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"


### PR DESCRIPTION
## Summary
- update Gradle settings to use Flutter plugin without old apply script

## Testing
- `git status --short`
- ❌ `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856afbc56883319cb1552e9c868e09